### PR TITLE
The dev package creates symlinks

### DIFF
--- a/libarchive/resources/README.rst
+++ b/libarchive/resources/README.rst
@@ -26,12 +26,12 @@ PyPI::
 Notes
 -----
 
-- The Ubuntu *libarchive* package maintainer refuses to place a "libarchive.so" symlink, so you'll have to place this yourself. Depending on your Ubuntu, this can be libarchive.so.12, libarchive.so.13, or libarchive.so.14 .
+- The Ubuntu `libarchive` package maintainer only provides a "libarchive.so" symlink in the dev package so you'll have to install the `libarchive-dev` package.
 
   For example::
 
-    /usr/lib/x86_64-linux-gnu$ sudo ln -s libarchive.so.12 libarchive.so
-
+    apt-get install libarchive-dev
+    
 - Encryption is not currently supported since it's not supported in the underlying library (*libarchive*). Note `this inquiry <https://github.com/libarchive/libarchive/issues/579>`_ and the `wishlist item <https://github.com/libarchive/libarchive/wiki/WishList#encrypted-backup-support>`_.
 
 


### PR DESCRIPTION
No need to complicate things for users by manual symlinking, just installing the dev package creates symlinks as well and is easier for users.