### PR TITLE
Update archive_entry.py

### DIFF
--- a/libarchive/adapters/archive_entry.py
+++ b/libarchive/adapters/archive_entry.py
@@ -96,7 +96,7 @@ class ArchiveEntry(object):
     @property
     def filetype(self):
         filetype = _archive_entry_filetype(self.__entry_res)
-        flags = dict([(k, (v & filetype) > 0) 
+        flags = dict([(k, v == filetype) 
                       for (k, v) 
                       in libarchive.constants.archive_entry.FILETYPES.items()])
 


### PR DESCRIPTION
Fixing a bug in filetype detection for the ArchiveEntry class, which caused multiple IF* flags to be set for certain filetypes.