### PR TITLE
fix ctypes.util.find_library usage

### DIFF
--- a/libarchive/library.py
+++ b/libarchive/library.py
@@ -6,7 +6,7 @@ import ctypes.util
 
 _LOGGER = logging.getLogger(__name__)
 
-_LIBRARY_NAME = 'libarchive'
+_LIBRARY_NAME = 'archive'
 _LIBRARY_FILENAME = 'libarchive.so'
 
 def find_and_load_library():
@@ -26,19 +26,18 @@ def find_and_load_library():
             filepath = os.path.join(path, _LIBRARY_FILENAME)
             search_filepaths.append(filepath)
 
-    # Search for our library using whatever search-path ctypes uses (not the same 
-    # as `LD_LIBRARY_PATH`).
-
-    filepath = ctypes.util.find_library(_LIBRARY_NAME)
-    if filepath is not None:
-        search_filepaths.append(filepath)
-
     # Load the first one available.
 
     found_filepath = None
     for filepath in search_filepaths:
         if os.path.exists(filepath) is True:
             return filepath
+
+    # Search for our library using whatever search-path ctypes uses (not the same
+    # as `LD_LIBRARY_PATH`).
+    filepath = ctypes.util.find_library(_LIBRARY_NAME)
+    if filepath is not None:
+        return filepath
 
     # Fallback on the naively trying to load the filename.
 

--- a/libarchive/resources/README.rst
+++ b/libarchive/resources/README.rst
@@ -28,12 +28,6 @@ PyPI::
 Notes
 -----
 
-- The Ubuntu `libarchive` package maintainer only provides a "libarchive.so" symlink in the dev package so you'll have to install the `libarchive-dev` package.
-
-  For example::
-
-    apt-get install libarchive-dev
-
 - Encryption is not currently supported since it's not supported in the underlying library (*libarchive*). Note `this inquiry <https://github.com/libarchive/libarchive/issues/579>`_ and the `wishlist item <https://github.com/libarchive/libarchive/wiki/WishList#encrypted-backup-support>`_.
 
 - OS X has a system version of `libarchive` that is very old. As a result, many users have encountered issues importing an alternate one. Specifically, often they install a different one via Brew but this will not be [sym]linked into the system like other packages. This is a precaution taken by Brew to prevent undefined behavior in the parts of OS X that depend on the factory version. In order to work around this, you should set `LD_LIBRARY_PATH` (or prepend if `LD_LIBRARY_PATH` is already defined) with the path of the location of the library version you want to use. You'll want to set this from your user-profile script (unless your environment can not support this and you need to prepend something like "LD_LIBRARY_PATH=/some/path" to the front of the command-line or set it via `os.environ` above where you import this package). A `tool <tools/brew_find_libarchive>`_ has been provided that will print the path of the first version of `libarchive` installed via Brew. Just copy-and-paste it. Thanks to @SkyLeach for discussing the issue and treatments.


### PR DESCRIPTION
Per https://docs.python.org/2/library/ctypes.html the find_library
function should be called "without any prefix like lib, suffix like .so,
.dylib or version number".

 - change _LIBRARY_NAME from "libarchive" to "archive" as required

 - move find_library logic after the *_LIBRARY_PATH logic to preserve
   current behavior. I suspect that the LD_LIBRARY_PATH logic is not
   actually necessary, but a side effect of this bug. I'm leaving it
   alone because I can't test all existing configurations to confirm
   that.

 - if find_library returns a result, use it unconditionally. Trying to
   confirm it is unnecessary (find_library would have returned None
   otherwise) and impossible without duplicating all of the linker's
   logic. The result will be something like "libarchive.so.13" (without
   a path) which will just do the right thing when used with LoadLibrary.

 - remove note about installing libarchive-dev, that isn't needed