### PR TITLE
Fixed library finding for other platforms/package managers.

### DIFF
--- a/libarchive/library.py
+++ b/libarchive/library.py
@@ -6,7 +6,7 @@ import ctypes.util
 
 _LOGGER = logging.getLogger(__name__)
 
-_LIBRARY_NAME = 'libarchive'
+_LIBRARY_NAME = ['libarchive', 'archive']
 _LIBRARY_FILENAME = 'libarchive.so'
 
 def find_and_load_library():
@@ -29,9 +29,10 @@ def find_and_load_library():
     # Search for our library using whatever search-path ctypes uses (not the same 
     # as `LD_LIBRARY_PATH`).
 
-    filepath = ctypes.util.find_library(_LIBRARY_NAME)
-    if filepath is not None:
-        search_filepaths.append(filepath)
+    for library_name in _LIBRARY_NAME:
+        filepath = ctypes.util.find_library(library_name)
+        if filepath is not None:
+            search_filepaths.append(filepath)
 
     # Load the first one available.
 

--- a/libarchive/library.py
+++ b/libarchive/library.py
@@ -6,7 +6,7 @@ import ctypes.util
 
 _LOGGER = logging.getLogger(__name__)
 
-_LIBRARY_NAME = ['libarchive', 'archive']
+_LIBRARY_NAMES = ['libarchive', 'archive']
 _LIBRARY_FILENAME = 'libarchive.so'
 
 def find_and_load_library():
@@ -29,7 +29,7 @@ def find_and_load_library():
     # Search for our library using whatever search-path ctypes uses (not the same 
     # as `LD_LIBRARY_PATH`).
 
-    for library_name in _LIBRARY_NAME:
+    for library_name in _LIBRARY_NAMES:
         filepath = ctypes.util.find_library(library_name)
         if filepath is not None:
             search_filepaths.append(filepath)


### PR DESCRIPTION
`libarchive.so` is called `archive.dll` on Windows, which means that `ctypes.util.find_library` won't find `libarchive` on Windows. This PR calls `find_library` on `archive` if `libarchive` didn't work, thereby making this package function correctly on Windows.