### PR TITLE
Raise detailed exception from `get_blocks()` on error

### DIFF
--- a/libarchive/adapters/archive_read.py
+++ b/libarchive/adapters/archive_read.py
@@ -209,6 +209,9 @@ def _read_by_block(archive_res):
         elif r == libarchive.constants.archive.ARCHIVE_EOF:
             break
 
+        elif r < 0:
+            message = c_archive_error_string(archive_res)
+            raise libarchive.exception.ArchiveError(message)
         else:
             raise ValueError("Read failed (archive_read_data_block): (%d)" %
                              (r,))


### PR DESCRIPTION
- if the return from `archive_read_data_block`
  is an error ( less than 0 ), look up the reported
  error string and raise an archive exception
  with the error string